### PR TITLE
Added Device and Sound support on PushOver messaging

### DIFF
--- a/vibration_settings.ini
+++ b/vibration_settings.ini
@@ -19,9 +19,12 @@ boot_message =
 
 # Pushover
 # Enter your User API Key and App API key here
+# Optionally, enter the device and sound also.  Valid sounds are listed at https://pushover.net/api#sounds
 [pushover]
 user_api_key = 
 app_api_key = 
+device =
+sound =
 
 [mqtt]
 #sample config


### PR DESCRIPTION
Hi Shmootpy

Saw your rpi-appliance-monitor project on github and thought this is perfect for me! My pi Zero W and vibration sensor have been ordered, and I am awaiting delivery.

When I looked into your code, I saw features missing in the PushOver notification that would be necessary for me. The particular device I want to receive the message, and a specific sound to play (both optional)

So I forked the project and made the mods. But since I don’t have a Pi Zero W to test with, I had to test my methods isolated in another script. The changes were simple and I am confident they will work but cannot (_for now_) perform a fully integrated test.

If you would rather I perform the fully integrated tests when I receive the Pi Zero, just refuse the pull request.

Thanks for the great work.
