### PR TITLE
Make Pushbullet show message at iOS

### DIFF
--- a/vibration.py
+++ b/vibration.py
@@ -31,7 +31,7 @@ def mqtt(msg):
 
 def pushbullet(cfg, msg):
     try:
-        data_send = {"type": "note", "title": "VibrationBot", "body": msg}
+        data_send = {"type": "note", "body": msg}
         requests.post(
             'https://api.pushbullet.com/v2/pushes',
             data=json.dumps(data_send),


### PR DESCRIPTION
If setting the title of the message, only the title will show in the iOS notification. If omitting the title, the message is shown.