### PR TITLE
Add setting for debug messages

### DIFF
--- a/vibration.py
+++ b/vibration.py
@@ -191,6 +191,8 @@ def heartbeat():
     threading.Timer(1, heartbeat).start()
 
 
+logging.basicConfig(format='%(message)s', level=logging.INFO)
+
 if len(sys.argv) == 1:
     logging.critical("No config file specified")
     sys.exit()
@@ -232,7 +234,6 @@ slack_webhook = config.get('slack','webhook_url')
 iftt_maker_channel_event = config.get('iftt','maker_channel_event')
 iftt_maker_channel_key = config.get('iftt','maker_channel_key')
 
-logging.basicConfig(format='%(message)s', level=logging.INFO)
 if verbose:
     logging.getLogger().setLevel(logging.DEBUG)
 

--- a/vibration_settings.ini
+++ b/vibration_settings.ini
@@ -1,4 +1,7 @@
 [main]
+# Do you want debug messages?
+verbose = yes
+
 # This is the GPIO pin your 801s sensor is connected to
 sensor_pin = 14
 


### PR DESCRIPTION
I am running this on the low resource RPi Zero W, and I was thinking that I didn't want the heartbeat messages in the logs.

So I added a small setting that I can turn on while developing and off in production.