### PR TITLE
Mark error in exit code

### DIFF
--- a/vibration.py
+++ b/vibration.py
@@ -192,7 +192,7 @@ def heartbeat():
 
 if len(sys.argv) == 1:
     print "No config file specified"
-    sys.exit()
+    sys.exit(1)
 
 vibrating = False
 appliance_active = False


### PR DESCRIPTION
Useful for scripting.

I'm running this program via an init script, and it needs the error code to detect failure. Otherwise it thinks that everything went fine.