### PR TITLE
Minor spelling fixes to vibration settings.

### DIFF
--- a/vibration_settings.ini
+++ b/vibration_settings.ini
@@ -5,10 +5,10 @@ verbose = yes
 # This is the GPIO pin your 801s sensor is connected to
 sensor_pin = 14
 
-# The monitor will think your appliane has started when it has detected vibrations for this many consecutive seconds
+# The monitor will think your appliance has started when it has detected vibrations for this many consecutive seconds
 seconds_to_start = 10
 
-# The monitor will think your appliane has finished when it has detected no vibrations for this many consecutive seconds
+# The monitor will think your appliance has finished when it has detected no vibrations for this many consecutive seconds
 seconds_to_end = 10
 
 # The message sent when your appliance has started (blank to send no message)


### PR DESCRIPTION
The word "Appliance" was misspelled in a couple spots.