### PR TITLE
SSL Email Support

### DIFF
--- a/vibration.py
+++ b/vibration.py
@@ -36,8 +36,11 @@ def email(msg):
         message_text.replace_header('Content-Type', 'text/html')
         message_alternative.attach(message_text)
 
-        s = smtplib.SMTP(email_server, email_port)
-        s.starttls()
+        if email_ssl is True:
+            s = smtplib.SMTP_SSL(email_server, email_port)
+        else:
+            s = smtplib.SMTP(email_server, email_port)
+            s.starttls()
         s.login(email_sender, email_password)
         s.sendmail(email_sender, email_recipient, message.as_string())
         s.quit()
@@ -280,6 +283,7 @@ email_sender = config.get('email', 'sender')
 email_password = config.get('email', 'password')
 email_server = config.get('email', 'server')
 email_port = config.get('email', 'port')
+email_ssl = config.getboolean('email', 'ssl')
 telegram_api_token = config.get('telegram', 'telegram_api_token')
 telegram_user_id = config.get('telegram', 'telegram_user_id')
 

--- a/vibration_settings.ini
+++ b/vibration_settings.ini
@@ -72,17 +72,20 @@ maker_channel_key =
 maker_channel_event =
 
 [email]
+# For services that use SSL only (e.g. on port 465), set ssl to true
 # sample config
 # sender = testsender@example.com
 # recipient = testrecipient@example.com
 # server = smtp.example.com
 # port = 25
 # password = hunter2
+# ssl = false
 sender =
 recipient =
 server =
 port =
 password =
+ssl = false
 
 # Create a new Telegram Bot and get the API token by talking with @BotFather
 # Get your Telegram user ID by talking with @myidbot and asking /getid


### PR DESCRIPTION
Some email services only support SSL-only connections, typically on port 465.