### PR TITLE
systemd service for easily managing multiple monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,20 @@ Create the settings file [`/home/pi/vibration_settings.ini`](https://raw.githubu
 * If you want email notifications, fill in SMTP information under [email] section.
 * If you want Telegram bot messages, fill in your Telegram bot API key and your Telegram user ID under [telegram] section.
 
+
+## Simple Install
 Edit `/etc/rc.local` to make the program run when the device boots up.
 
 Add before the `exit` line:
 
     python /home/pi/vibration.py /home/pi/vibration_settings.ini &
+
+## Advanced Install
+If you want to manage multiple sensors, or track the script as a systemd service,
+a service file has been provided.
+
+    sudo cp /home/pi/rpi-appliance-monitor@.service /etc/systemd/system
+    sudo systemctl enable --now rpi-appliance-monitor@vibration_settings
 
 > Multiple sensor expert mode: Add and additional line for each additional sensor. One for each of the settings files you created.
 

--- a/rpi-appliance-monitor@.service
+++ b/rpi-appliance-monitor@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Raspberry PI Appliance Monitor for %I
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpi-appliance-monitor@.service
+++ b/rpi-appliance-monitor@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Raspberry PI Appliance Monitor for %I
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=3
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/rpi-appliance-monitor
+ExecStart=/usr/bin/python3 vibration.py %I.ini
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Multiple instances can be run easily with different configuration files like
    systemctl enable --now rpi-appliance-monitor@washer
    systemctl enable --now rpi-appliance-monitor@dryer

(Assuming you have multiple configuration files named washer.ini and dryer.ini)